### PR TITLE
修復郵件api發送者與nodemailer錯誤

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -152,9 +152,17 @@ Content-Type: application/json
   "to": "recipient@example.com",
   "subject": "測試郵件",
   "text": "這是純文本內容",
-  "html": "<h1>這是 HTML 內容</h1><p>支持 HTML 格式</p>"
+  "html": "<h1>這是 HTML 內容</h1><p>支持 HTML 格式</p>",
+  "from": "sender@example.com"
 }
 ```
+
+**參數說明:**
+- `to` (必填): 收件人郵箱地址
+- `subject` (必填): 郵件主題
+- `text` (可選): 純文本內容
+- `html` (可選): HTML 格式內容
+- `from` (可選): 寄件人郵箱地址，如不提供則使用 SMTP 配置的用戶名
 
 **回應:**
 ```json
@@ -276,7 +284,8 @@ async function sendEmail() {
         to: 'recipient@example.com',
         subject: '測試郵件',
         text: '這是純文本內容',
-        html: '<h1>Hello World</h1><p>這是 HTML 郵件</p>'
+        html: '<h1>Hello World</h1><p>這是 HTML 郵件</p>',
+        from: 'sender@example.com'
       })
     });
 
@@ -300,7 +309,8 @@ curl -X POST http://localhost:3000/api/send-email \
     "to": "recipient@example.com",
     "subject": "測試郵件",
     "text": "這是純文本內容",
-    "html": "<h1>Hello World</h1><p>這是 HTML 郵件</p>"
+    "html": "<h1>Hello World</h1><p>這是 HTML 郵件</p>",
+    "from": "sender@example.com"
   }'
 ```
 

--- a/server.js
+++ b/server.js
@@ -312,7 +312,7 @@ app.delete('/api/admin/smtp-configs/:id', authenticateToken, async (req, res) =>
 // Public email sending endpoint (requires API key)
 app.post('/api/send-email', authenticateApiKey, async (req, res) => {
   try {
-    const { to, subject, text, html } = req.body;
+    const { to, subject, text, html, from } = req.body;
     
     // Find available SMTP configuration
     const availableConfigs = await prisma.smtpConfig.findMany({
@@ -341,7 +341,7 @@ app.post('/api/send-email', authenticateApiKey, async (req, res) => {
     const selectedConfig = availableConfigs[0];
 
     // Create transporter
-    const transporter = nodemailer.createTransporter({
+    const transporter = nodemailer.createTransport({
       host: selectedConfig.host,
       port: selectedConfig.port,
       secure: selectedConfig.port === 465,
@@ -352,7 +352,7 @@ app.post('/api/send-email', authenticateApiKey, async (req, res) => {
     });
 
     const mailOptions = {
-      from: selectedConfig.username,
+      from: from || selectedConfig.username, // Use custom sender or default to SMTP username
       to,
       subject,
       text,


### PR DESCRIPTION
Fix email sending API by correcting `nodemailer` method and adding custom sender support.

The email sending API failed due to a typo, `nodemailer.createTransporter`, which has been corrected to `nodemailer.createTransport`. This PR also introduces the ability to specify a custom `from` address in the email request body.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-b30528c5-45e2-4998-a47b-9c90ba2384d5) · [Cursor](https://cursor.com/background-agent?bcId=bc-b30528c5-45e2-4998-a47b-9c90ba2384d5)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)