### PR TITLE
Deploy and fix trust proxy setting

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,6 +17,9 @@ const app = express();
 const prisma = new PrismaClient();
 const PORT = process.env.PORT || 3000;
 
+// Trust proxy for rate limiting behind reverse proxy (Render, etc.)
+app.set('trust proxy', 1);
+
 // Security middleware
 app.use(helmet({
   contentSecurityPolicy: {


### PR DESCRIPTION
Set Express `trust proxy` to 1 to correctly handle `X-Forwarded-For` headers and fix `express-rate-limit` validation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e108831-f4de-4b18-8861-cfff2c51676e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e108831-f4de-4b18-8861-cfff2c51676e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

